### PR TITLE
Theming support (with included dark theme) and small extras and fixes

### DIFF
--- a/native/src/ReachVariantTool/main.cpp
+++ b/native/src/ReachVariantTool/main.cpp
@@ -23,6 +23,11 @@ int main(int argc, char *argv[]) {
       }
    #endif
    //
+      QString Style = QString::fromUtf8(ReachINI::UIWindowTitle::sTheme.currentStr.c_str());
+      QFile stylesheet(Style);
+      stylesheet.open(QFile::ReadOnly);
+      Style = QLatin1String(stylesheet.readAll());
+      a.setStyleSheet(Style);
    ReachVariantTool w;
    w.show();
    return a.exec();

--- a/native/src/ReachVariantTool/main.cpp
+++ b/native/src/ReachVariantTool/main.cpp
@@ -23,11 +23,11 @@ int main(int argc, char *argv[]) {
       }
    #endif
    //
-      QString Style = QString::fromUtf8(ReachINI::UIWindowTitle::sTheme.currentStr.c_str());
-      QFile stylesheet(Style);
-      stylesheet.open(QFile::ReadOnly);
-      Style = QLatin1String(stylesheet.readAll());
-      a.setStyleSheet(Style);
+   QString Style = QString::fromUtf8(ReachINI::UIWindowTitle::sTheme.currentStr.c_str());
+   QFile stylesheet(Style);
+   stylesheet.open(QFile::ReadOnly);
+   Style = QLatin1String(stylesheet.readAll());
+   a.setStyleSheet(Style);
    ReachVariantTool w;
    w.show();
    return a.exec();

--- a/native/src/ReachVariantTool/services/ini.cpp
+++ b/native/src/ReachVariantTool/services/ini.cpp
@@ -32,7 +32,7 @@ namespace ReachINI {
    namespace UIWindowTitle {
       REACHTOOL_MAKE_INI_SETTING(bShowFullPath,     "UIWindowTitle", true);
       REACHTOOL_MAKE_INI_SETTING(bShowVariantTitle, "UIWindowTitle", true);
-      REACHTOOL_MAKE_INI_SETTING(sTheme, "UIWindowTitle", "themes/dark.qss");
+      REACHTOOL_MAKE_INI_SETTING(sTheme, "UIWindowTitle", "themes/default.qss");
    }
    #undef REACHTOOL_MAKE_INI_SETTING
 }

--- a/native/src/ReachVariantTool/services/ini.cpp
+++ b/native/src/ReachVariantTool/services/ini.cpp
@@ -32,6 +32,7 @@ namespace ReachINI {
    namespace UIWindowTitle {
       REACHTOOL_MAKE_INI_SETTING(bShowFullPath,     "UIWindowTitle", true);
       REACHTOOL_MAKE_INI_SETTING(bShowVariantTitle, "UIWindowTitle", true);
+      REACHTOOL_MAKE_INI_SETTING(sTheme, "UIWindowTitle", "themes/dark.qss");
    }
    #undef REACHTOOL_MAKE_INI_SETTING
 }

--- a/native/src/ReachVariantTool/services/ini.h
+++ b/native/src/ReachVariantTool/services/ini.h
@@ -35,7 +35,7 @@ namespace ReachINI {
    namespace UIWindowTitle {
       REACHTOOL_MAKE_INI_SETTING(bShowFullPath,     "UIWindowTitle", true);
       REACHTOOL_MAKE_INI_SETTING(bShowVariantTitle, "UIWindowTitle", true);
-      REACHTOOL_MAKE_INI_SETTING(sTheme, "UIWindowTitle", "themes/dark.qss");
+      REACHTOOL_MAKE_INI_SETTING(sTheme, "UIWindowTitle", "themes/default.qss");
    }
    #undef REACHTOOL_MAKE_INI_SETTING
 }

--- a/native/src/ReachVariantTool/services/ini.h
+++ b/native/src/ReachVariantTool/services/ini.h
@@ -35,6 +35,7 @@ namespace ReachINI {
    namespace UIWindowTitle {
       REACHTOOL_MAKE_INI_SETTING(bShowFullPath,     "UIWindowTitle", true);
       REACHTOOL_MAKE_INI_SETTING(bShowVariantTitle, "UIWindowTitle", true);
+      REACHTOOL_MAKE_INI_SETTING(sTheme, "UIWindowTitle", "themes/dark.qss");
    }
    #undef REACHTOOL_MAKE_INI_SETTING
 }

--- a/native/src/ReachVariantTool/themes/dark.qss
+++ b/native/src/ReachVariantTool/themes/dark.qss
@@ -1,0 +1,280 @@
+QMainWindow{
+	color:#ffffff;
+	background-color:#121212;
+	}
+QToolTip{
+	color:#ffffff;
+	background-color:#525252;
+	border: 0px;
+	}
+QComboBox{
+	color:#ffffff;
+	background-color:#363636;
+	border-color:#878787;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	padding:3px;
+	}
+QComboBox:hover{
+	color:#ffffff;
+	background-color:#525252;
+	}
+QListView{
+	color:#ffffff;
+	background-color:#363636;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	}
+QLabel{
+	color:#ffffff;
+	}
+QTreeWidget{
+	color:#ffffff;
+	background-color:#242424;
+	border-style:solid;
+	border-color:#525252;
+	border-radius:1px;
+	padding:4px;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	}
+QTreeWidget::branch:open:has-children:!has-siblings,
+QTreeWidget::branch:open:has-children:has-siblings {
+	color:white;
+	padding:3px;
+	}
+QListWidget{
+	color:#ffffff;
+	background-color:#242424;
+	alternate-background-color:#303030;
+	border-style:solid;
+	border-color:#525252;
+	border-radius:1px;
+	padding:4px;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	}
+QListWidgetEx{
+	color:#ffffff;
+	background-color:#242424;
+	alternate-background-color:#303030;
+	border-style:solid;
+	border-color:#525252;
+	border-radius:1px;
+	padding:4px;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	}
+QCheckBox{
+	color:#ffffff;
+	padding:5px;
+	}
+QMenuBar{
+	color:#ffffff;
+	background-color:#121212;
+	}
+QStatusBar{
+	color:#ffffff;
+	background-color:#121212;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	}
+QMenu{
+	color:#ffffff;
+	background-color:#363636;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	}
+QAction{
+	color:#ffffff;
+	background-color:#363636;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	}
+QPlainTextEdit{
+	color:#ffffff;
+	background-color:#525252;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	padding:3px;
+	}
+QLineEdit{
+	color:#ffffff;
+	background-color:#525252;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	padding:3px;
+	border-radius:1px;
+	}
+QDateTimeEdit{
+	color:#ffffff;
+	background-color:#525252;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	padding:3px;
+	border-radius:1px;
+	}
+QPushButton{
+	color:#ffffff;
+	background-color:#242424;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	border-radius:1px;
+	padding:5px;
+	padding-right: 20px;
+	padding-left: 20px;
+	}
+QPushButton:hover{
+	background-color:#363636;
+	}
+QPushButton:pressed{
+	background-color:#6b6b6b;
+	color:#b7fbff;
+	}
+QSpinBox{
+	color:#ffffff;
+	background-color:#525252;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	padding:3px;
+	border-radius:1px;
+	}
+QDoubleSpinBox{
+	color:#ffffff;
+	background-color:#525252;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	padding:3px;
+	border-radius:1px;
+	}
+QTabWidget::pane{
+	color:#ffffff;
+	background-color:#242424;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	padding:3px;
+	border-radius:1px;
+	}
+QTabBar::tab{
+	color:#ffffff;
+	background-color:#363636;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	border:1px;
+	padding:3px;
+	}
+QTabBar::tab:selected{
+	color:#b7fbff;
+	background-color:#6b6b6b;
+	}
+QTabBar::tab:hover:!selected{
+	color:#ffffff;
+	background-color:#525252;
+	}
+QDialog{
+	color:#ffffff;
+	background-color:#121212;
+	}
+QGroupBox{
+	color:#ffffff;
+	background-color:#242424;
+	border: 2px #121212;
+	border-style: outset;
+	padding:5px;
+	border-radius: 1px;
+	}
+QGroupBox QPushButton{
+	color:#ffffff;
+	background-color:#363636;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	border-radius:1px;
+	padding:5px;
+	padding-right: 20px;
+	padding-left: 20px;
+	}
+QGroupBox QPushButton:hover{
+	background-color:#525252;
+	}
+QRadioButton{
+	color:#ffffff;
+	}
+QToolBox::tab{
+	color:#ffffff;
+	background-color:#363636;
+	}
+QToolBox QWidget{
+	color:#ffffff;
+	background-color:#242424;
+	}
+QToolBox QWidget QComboBox{
+	color:#ffffff;
+	background-color:#363636;
+	border-color:#878787;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	padding:3px;
+	}
+QTextEdit{
+	color:#ffffff;
+	background-color:#525252;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	border-style:solid;
+	border-color:#525252;
+	padding:3px;
+	}
+QTextEdit:disabled{
+	color:#c9c9c9;
+	background-color:#363636;
+	}
+QTreeView{
+	color:#ffffff;
+	background-color:#242424;
+	border-style:solid;
+	border-color:#525252;
+	border-radius:1px;
+	padding:4px;
+	selection-color:#b7fbff;
+	selection-background-color:#6b6b6b;
+	}
+QHeaderView{
+	color:#ffffff;
+	background-color:#363636;
+	border-style:solid;
+	border-color:#525252;
+	border:1px;
+	padding:3px;
+QHeaderView::section{
+	color:#ffffff;
+	background-color:#363636;
+	border-style:solid;
+	border-color:#525252;
+	border:1px;
+	padding:3px;
+	}
+QFrame{
+	border-color:#525252;
+	}

--- a/native/src/ReachVariantTool/themes/dark.qss
+++ b/native/src/ReachVariantTool/themes/dark.qss
@@ -16,6 +16,7 @@ QComboBox{
 	border-style:solid;
 	border-color:#525252;
 	padding:3px;
+	border-radius:1px
 	}
 QComboBox:hover{
 	color:#ffffff;
@@ -23,9 +24,10 @@ QComboBox:hover{
 	}
 QListView{
 	color:#ffffff;
-	background-color:#363636;
+	background-color:#242424;
 	selection-color:#b7fbff;
 	selection-background-color:#6b6b6b;
+	border-radius:1px;
 	}
 QLabel{
 	color:#ffffff;
@@ -87,6 +89,10 @@ QMenu{
 	selection-color:#b7fbff;
 	selection-background-color:#6b6b6b;
 	}
+QMenuBar::item:selected{
+	color:#b7fbff;
+	background-color:#6b6b6b;
+	}
 QAction{
 	color:#ffffff;
 	background-color:#363636;
@@ -101,6 +107,7 @@ QPlainTextEdit{
 	border-style:solid;
 	border-color:#525252;
 	padding:3px;
+	border-radius:1px;
 	}
 QLineEdit{
 	color:#ffffff;
@@ -138,6 +145,10 @@ QPushButton:hover{
 	background-color:#363636;
 	}
 QPushButton:pressed{
+	background-color:#6b6b6b;
+	color:#b7fbff;
+	}
+QPushButton:checked{
 	background-color:#6b6b6b;
 	color:#b7fbff;
 	}
@@ -180,6 +191,7 @@ QTabBar::tab{
 	border-color:#525252;
 	border:1px;
 	padding:3px;
+	border-radius:1px;
 	}
 QTabBar::tab:selected{
 	color:#b7fbff;
@@ -236,6 +248,7 @@ QToolBox QWidget QComboBox{
 	border-style:solid;
 	border-color:#525252;
 	padding:3px;
+	border-radius:1px;
 	}
 QTextEdit{
 	color:#ffffff;
@@ -245,6 +258,7 @@ QTextEdit{
 	border-style:solid;
 	border-color:#525252;
 	padding:3px;
+	border-radius:1px;
 	}
 QTextEdit:disabled{
 	color:#c9c9c9;
@@ -260,21 +274,16 @@ QTreeView{
 	selection-color:#b7fbff;
 	selection-background-color:#6b6b6b;
 	}
-QHeaderView{
-	color:#ffffff;
-	background-color:#363636;
-	border-style:solid;
-	border-color:#525252;
-	border:1px;
-	padding:3px;
 QHeaderView::section{
 	color:#ffffff;
 	background-color:#363636;
-	border-style:solid;
-	border-color:#525252;
-	border:1px;
-	padding:3px;
+    padding: 3px;
+    border: 1px solid #6c6c6c;
 	}
-QFrame{
-	border-color:#525252;
+QSplitter::handle{
+	background-color:#6b6b6b;
+	padding: 2px;
+	}
+QSplitter::handle:vertical{
+	height: 1px;
 	}

--- a/native/src/ReachVariantTool/themes/default.qss
+++ b/native/src/ReachVariantTool/themes/default.qss
@@ -1,0 +1,1 @@
+//This is empty because everything will be default unless dictated otherwise.

--- a/native/src/ReachVariantTool/ui/main_window.cpp
+++ b/native/src/ReachVariantTool/ui/main_window.cpp
@@ -187,6 +187,7 @@ ReachVariantTool::ReachVariantTool(QWidget *parent) : QMainWindow(parent) {
    QObject::connect(this->ui.actionOpen,    &QAction::triggered, this, QOverload<>::of(&ReachVariantTool::openFile));
    QObject::connect(this->ui.actionSave,    &QAction::triggered, this, &ReachVariantTool::saveFile);
    QObject::connect(this->ui.actionSaveAs,  &QAction::triggered, this, &ReachVariantTool::saveFileAs);
+   QObject::connect(this->ui.actionExit, SIGNAL(triggered()), QApplication::instance(), SLOT(quit()));
    QObject::connect(this->ui.actionOptions, &QAction::triggered, &ProgramOptionsDialog::get(), &ProgramOptionsDialog::open);
    QObject::connect(this->ui.actionEditScript, &QAction::triggered, [this]() {
       (new MegaloScriptEditorWindow(this))->exec();

--- a/native/src/ReachVariantTool/ui/main_window.ui
+++ b/native/src/ReachVariantTool/ui/main_window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>618</width>
-    <height>535</height>
+    <width>682</width>
+    <height>623</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -378,8 +378,8 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>618</width>
-     <height>21</height>
+     <width>682</width>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">

--- a/native/src/ReachVariantTool/ui/main_window/page_multiplayer_metadata.ui
+++ b/native/src/ReachVariantTool/ui/main_window/page_multiplayer_metadata.ui
@@ -42,7 +42,7 @@
    <item row="4" column="3">
     <widget class="QComboBox" name="engineCategory">
      <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
        <horstretch>2</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>

--- a/native/src/ReachVariantTool/ui/main_window/page_player_traits.ui
+++ b/native/src/ReachVariantTool/ui/main_window/page_player_traits.ui
@@ -448,81 +448,81 @@
        </item>
        <item row="5" column="1">
         <widget class="QComboBox" name="fieldShieldRegenRateOver">
-           <item>
-              <property name="text">
-                 <string>Unchanged</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>-25%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>-10%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>-5%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>0%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>10%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>25%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>50%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>75%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>90%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>100%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>110%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>125%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>150%</string>
-              </property>
-           </item>
-           <item>
-              <property name="text">
-                 <string>200%</string>
-              </property>
-           </item>
+         <item>
+          <property name="text">
+           <string>Unchanged</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>-25%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>-10%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>-5%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>0%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>10%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>25%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>50%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>75%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>90%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>100%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>110%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>125%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>150%</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>200%</string>
+          </property>
+         </item>
         </widget>
        </item>
        <item row="6" column="1">
@@ -540,37 +540,37 @@
          </item>
          <item>
           <property name="text">
-           <string>Unknown 1</string>
+           <string>None</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Unknown 2</string>
+           <string>10%</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Unknown 3</string>
+           <string>25%</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Unknown 4</string>
+           <string>50%</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Unknown 5</string>
+           <string>100%</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Unknown 6</string>
+           <string>100%(?)</string>
           </property>
          </item>
          <item>
           <property name="text">
-           <string>Unknown 7</string>
+           <string>100%(?)</string>
           </property>
          </item>
         </widget>

--- a/native/src/ReachVariantTool/ui/options_window.cpp
+++ b/native/src/ReachVariantTool/ui/options_window.cpp
@@ -1,10 +1,7 @@
 #include "options_window.h"
 #include "../helpers/ini.h"
 #include "../services/ini.h"
-#include <qdir.h>
-#include <qstringlist.h>
 #include <QFileDialog>
-#include <filesystem>
 
 ProgramOptionsDialog::ProgramOptionsDialog(QWidget* parent) : QDialog(parent) {
    ui.setupUi(this);

--- a/native/src/ReachVariantTool/ui/options_window.cpp
+++ b/native/src/ReachVariantTool/ui/options_window.cpp
@@ -1,6 +1,10 @@
 #include "options_window.h"
 #include "../helpers/ini.h"
 #include "../services/ini.h"
+#include <qdir.h>
+#include <qstringlist.h>
+#include <QFileDialog>
+#include <filesystem>
 
 ProgramOptionsDialog::ProgramOptionsDialog(QWidget* parent) : QDialog(parent) {
    ui.setupUi(this);
@@ -54,6 +58,10 @@ ProgramOptionsDialog::ProgramOptionsDialog(QWidget* parent) : QDialog(parent) {
    QObject::connect(this->ui.optionVariantNameInWindowTitle, &QCheckBox::stateChanged, [](int state) {
       ReachINI::UIWindowTitle::bShowVariantTitle.pending.b = state == Qt::CheckState::Checked;
    });
+   QObject::connect(this->ui.optionTheme, &QLineEdit::textEdited, this, [](const QString& text) {
+       ReachINI::UIWindowTitle::sTheme.pendingStr = text.toUtf8();
+    });
+   QObject::connect(this->ui.themeFileDialog, &QPushButton::pressed, this, &ProgramOptionsDialog::openFile);
 }
 void ProgramOptionsDialog::close() {
    ReachINI::get().abandon_pending_changes();
@@ -130,6 +138,7 @@ void ProgramOptionsDialog::refreshWidgetsFromINI() {
       const QSignalBlocker blocker1(this->ui.optionVariantNameInWindowTitle);
       this->ui.optionFullFilePathsInWindowTitle->setChecked(ReachINI::UIWindowTitle::bShowFullPath.current.b);
       this->ui.optionVariantNameInWindowTitle->setChecked(ReachINI::UIWindowTitle::bShowVariantTitle.current.b);
+      this->ui.optionTheme->setText(ReachINI::UIWindowTitle::sTheme.currentStr.c_str());
    }
 }
 void ProgramOptionsDialog::saveAndClose() {
@@ -163,4 +172,12 @@ void ProgramOptionsDialog::defaultSaveTypeChanged() {
    else if (this->ui.defaultSavePathUseCustom->isChecked())
       which = type::custom;
    ReachINI::DefaultSavePath::uPathType.pending.u = (uint32_t)which;
+}
+
+void ProgramOptionsDialog::openFile() {
+    QString fileName = QFileDialog::getOpenFileName(this, tr("Select theme"), "~/", tr("QT Stylesheets (*.qss)"));
+    if (!fileName.isNull()) {
+        this->ui.optionTheme->setText(fileName.toUtf8());
+        ReachINI::UIWindowTitle::sTheme.pendingStr = fileName.toUtf8();
+    }
 }

--- a/native/src/ReachVariantTool/ui/options_window.h
+++ b/native/src/ReachVariantTool/ui/options_window.h
@@ -27,6 +27,7 @@ class ProgramOptionsDialog : public QDialog {
       void defaultLoadTypeChanged();
       void defaultSaveTypeChanged();
       //
+      void openFile();
    private:
       Ui::ProgramOptionsDialog ui;
 };

--- a/native/src/ReachVariantTool/ui/options_window.ui
+++ b/native/src/ReachVariantTool/ui/options_window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>588</width>
-    <height>424</height>
+    <width>589</width>
+    <height>518</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -64,7 +64,7 @@
    <item row="3" column="0">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Window title</string>
+      <string>Window</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0">
@@ -74,10 +74,33 @@
         </property>
        </widget>
       </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="optionTheme"/>
+      </item>
       <item row="1" column="0">
        <widget class="QCheckBox" name="optionVariantNameInWindowTitle">
         <property name="text">
          <string>Show the game variant's title in the window title</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Current theme (Restart required)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QPushButton" name="themeFileDialog">
+        <property name="text">
+         <string>...</string>
         </property>
        </widget>
       </item>

--- a/native/src/ReachVariantTool/ui/script_editor.cpp
+++ b/native/src/ReachVariantTool/ui/script_editor.cpp
@@ -5,6 +5,7 @@
 MegaloScriptEditorWindow::MegaloScriptEditorWindow(QWidget* parent) : QDialog(parent) {
    ui.setupUi(this);
    //
+   this->setWindowFlags(windowFlags() | Qt::WindowMaximizeButtonHint);
    QObject::connect(this->ui.navigation, &QListWidget::currentItemChanged, this, [this](QListWidgetItem* current, QListWidgetItem* previous) {
       auto stack = this->ui.stack;
       if (current->text() == "Metadata Strings") {

--- a/native/src/ReachVariantTool/ui/script_editor/page_script_code.ui
+++ b/native/src/ReachVariantTool/ui/script_editor/page_script_code.ui
@@ -76,6 +76,9 @@
            <pointsize>10</pointsize>
           </font>
          </property>
+         <property name="tabStopWidth">
+          <number>24</number>
+         </property>
          <property name="acceptRichText">
           <bool>false</bool>
          </property>

--- a/native/src/ReachVariantTool/ui/script_editor/page_script_code.ui
+++ b/native/src/ReachVariantTool/ui/script_editor/page_script_code.ui
@@ -86,13 +86,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QFrame" name="compileLogWrapper">
-      <property name="frameShape">
-       <enum>QFrame::Panel</enum>
-      </property>
-      <property name="frameShadow">
-       <enum>QFrame::Sunken</enum>
-      </property>
+     <widget class="QWidget" name="compileLogWrapper" native="true">
       <layout class="QVBoxLayout" name="verticalLayout">
        <property name="spacing">
         <number>0</number>
@@ -110,13 +104,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QFrame" name="frame">
-         <property name="frameShape">
-          <enum>QFrame::WinPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Raised</enum>
-         </property>
+        <widget class="QWidget" name="widget" native="true">
          <layout class="QHBoxLayout" name="horizontalLayout">
           <property name="spacing">
            <number>2</number>


### PR DESCRIPTION
Custom theming support for RVT using QT stylesheets. Included is a themes folder with a dark theme that should work for all of RVT's UI elements. The dark theme can be selected via the options menu.

"small extras and fixes" includes a maximize button for the Script and Data editor window (nothing seemed to have a value for "whatsThis" so I'm not sure if the help button was planned on being used or not), values for Shield Vampirism, decreasing the size of tabs in the code editor to match 3 spaces, and making File->Exit work.